### PR TITLE
Fix: Handle None value from data_json.get('extra')

### DIFF
--- a/mqtt_sub.py
+++ b/mqtt_sub.py
@@ -125,8 +125,10 @@ def subscribe(client: mqtt_client):
                             open_drone_id.decode_valid_blocks(UASdata, valid_open_drone_id_blocks)
                             try:
                                 extra_json = data_json.get('extra')
+                                if extra_json is None:
+                                    extra_json = {}
                             except:
-                                extra_json = ''
+                                extra_json = {}
 
                             if hasattr(config, 'log_path'):
                                 if 'filename_rid' not in globals():


### PR DESCRIPTION
- Changed extra_json handling to use empty dict {} instead of empty string
- Prevents TypeError when print_payload() tries len(extra_json)
- SBS export feature now works correctly with RemoteID MQTT data
- Fixes silent exception that prevented SBS transmission to connected clients

The original code's try/except block could not catch the issue since .get() does not throw exceptions - it returns None if the key is missing. When print_payload() attempted len(extra_json), a TypeError was silently swallowed by the outer exception handler, preventing SBS export from executing.